### PR TITLE
Remove unneeded peerDependency ember-source

### DIFF
--- a/ember-content-editable-modifier/package.json
+++ b/ember-content-editable-modifier/package.json
@@ -44,9 +44,6 @@
     "rollup": "^3.18.0",
     "rollup-plugin-copy": "^3.4.0"
   },
-  "peerDependencies": {
-    "ember-source": "^4.0.0 || >= 5.0.0"
-  },
   "engines": {
     "node": "14.* || 16.* || >= 18"
   },


### PR DESCRIPTION
ember-source: removed because the embroider / auto-import know what we intend - it's not bad to have if someone manages their dep graph correctly, which is easier with pnpm, but not everyone gets it right, and folks have a hard time tracking down errors

ref https://github.com/ember-cli/ember-addon-blueprint/pull/35